### PR TITLE
Remove unnecessary logging (and a note on input)

### DIFF
--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -26,6 +26,10 @@ func Init(c net.Conn) {
 
 	/* Modify  End */
 
+	if len(plugins) < 1 {
+		return
+	}
+
 	// execute plugins that run on startup (auto)
 	c.Write([]byte("\n[*] Auto-Plugins:\n"))
 	for _, plugin := range plugins {
@@ -39,10 +43,10 @@ func Init(c net.Conn) {
 // Execute ...
 func Execute(pluginName string, c net.Conn) {
 	if _, ok := plugins[pluginName]; ok {
-    	plugins[pluginName].Execute(c)
+		plugins[pluginName].Execute(c)
 	} else {
 		c.Write([]byte("[!] Plugin does not exist\n"))
-	}	
+	}
 }
 
 // List ...

--- a/server/server.go
+++ b/server/server.go
@@ -143,7 +143,6 @@ func Run(s *yamux.Session, c net.Conn) {
 	gs = s
 	session = s
 	defer c.Close()
-	fmt.Printf("[xc]:")
 	sr := sendReader(os.Stdin)  // intercepts input that is given on stdin and then send to the network
 	rw := recvWriter(os.Stdout) // intercepts output that is to received from network andthen  send to stdout
 	go io.Copy(c, sr)


### PR DESCRIPTION
I was reading a bit through the code looking for things to improve.
One thing that bothers me about xc is that it does not have any tab completion or history.
I am curious if this could be added if the server input wasn't directly send and then handled by the client.

But instead handled by the server first by some library like readline, this way you could add tab completion for the builtin commands but also files, and move through history with the arrow keys. Only after the enter key is pressed will the server send the command string to the client.
This implementation of course comes with it's own issues.
But I think it could be doable, if I find some time I could look more into it.