### PR TITLE
New homedir logic

### DIFF
--- a/client/client_windows.go
+++ b/client/client_windows.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net"
 	"os"
-	"os/user"
 	"strings"
 	"time"
 
@@ -24,8 +23,10 @@ import (
 func Run(s *yamux.Session, c net.Conn) {
 	defer c.Close()
 	scanner := bufio.NewScanner(c)
-	usr, _ := user.Current()
-	homedir := usr.HomeDir
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		homedir = "C:"
+	}
 	// init
 	plugins.Init(c)
 	prompt(c)


### PR DESCRIPTION
Hey,

I noticed that during some reverse shell pops especially in Windows, users such as `IUSRblaablaa` might not have HOME set and xc crashed due to this. Cannot find any IIS to test with and lost my crash logs :)

But I've fixed this and also managed to drop `os/user` as part of process (to make even smaller binary)! Great rshell, just love it!