### PR TITLE
Allow socket reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ git clone --recurse-submodules https://github.com/xct/xc.git
 GO111MODULE=off go get golang.org/x/sys/...
 GO111MODULE=off go get golang.org/x/text/encoding/unicode
 GO111MODULE=off go get github.com/hashicorp/yamux
+GO111MODULE=off go get github.com/libp2p/go-reuseport
 sudo apt-get install rlwrap upx
 ``` 
 

--- a/xc.go
+++ b/xc.go
@@ -15,6 +15,7 @@ import (
 	"./client"
 	"./server"
 	"github.com/hashicorp/yamux"
+	"github.com/libp2p/go-reuseport"
 	"path/filepath"
 	
 )
@@ -43,7 +44,7 @@ func main() {
 		fmt.Println(banner)
 		
 		// server mode
-		listener, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", *portPtr))
+		listener, err := reuseport.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", *portPtr))
 		if err != nil {
 			log.Fatalln("Unable to bind to port")
 		}


### PR DESCRIPTION
When working on one of the HTB prolabs only a few outbound ports were allowed in the remote firewall. This made me notice that `xc` did not support socket reuse, which made it hard to get multiple shells on different systems. 
 
This PR implements the [go-reuseport](https://github.com/libp2p/go-reuseport) library. This library basically tries to set both `SO_REUSEADDR` and `SO_REUSEPORT` as socket options, allowing for socket reuse.

Situation before PR: 
![before](https://user-images.githubusercontent.com/104627239/169649357-05fe8c15-1313-4e89-8f86-6aa90455e617.png)
 
Situation after PR: 
![after](https://user-images.githubusercontent.com/104627239/169649356-8f2602f0-72fb-4ecc-b68b-ce160f03565b.png)

